### PR TITLE
netatalk: move package here from packages feed

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -1,0 +1,98 @@
+#
+# Copyright (C) 2009-2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netatalk
+PKG_VERSION:=3.1.12
+PKG_RELEASE:=3
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/netatalk
+PKG_HASH:=1560f83a3da41be97e0b70a96e2402159b8ddc631d38538360b14784beada5d1
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+
+PKG_CPE_ID:=cpe:/a:netatalk:netatalk
+
+PKG_BUILD_DEPENDS:=libevent2
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/netatalk
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Filesystem
+  DEPENDS:=+libattr +libdb47 +libgcrypt +libopenssl
+  TITLE:=netatalk
+  URL:=http://netatalk.sourceforge.net
+  MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+endef
+
+define Package/netatalk/decription
+  Netatalk is a freely-available Open Source AFP fileserver.
+  It also provides a kernel level implementation of the AppleTalk
+  Protocol Suite.
+endef
+
+TARGET_CFLAGS += -std=gnu99
+
+CONFIGURE_ARGS += \
+	--disable-afs \
+	--enable-hfs \
+	--disable-debugging \
+	--disable-shell-check \
+	--disable-timelord \
+	--disable-a2boot \
+	--disable-cups \
+	--disable-tcp-wrappers \
+	--with-cnid-default-backend=dbd \
+	--with-bdb="$(STAGING_DIR)/usr/" \
+	--with-libevent=no \
+	--with-libgcrypt-dir="$(STAGING_DIR)/usr" \
+	--with-ssl-dir="$(STAGING_DIR)/usr" \
+	--with-uams-path="/usr/lib/uams" \
+	--without-acls \
+	--without-kerberos \
+	--without-mysql \
+	--with-mysql-config=false \
+	--without-pam \
+	--disable-admin-group \
+	--disable-srvloc \
+	--disable-zeroconf \
+	$(if $(CONFIG_SHADOW_PASSWORDS),--with-shadow,--without-shadow) \
+	--without-dtrace \
+	--without-ldap
+
+define Package/netatalk/conffiles
+/etc/afp.conf
+/etc/extmap.conf
+/etc/netatalk/
+endef
+
+define Package/netatalk/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/lib/uams
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libatalk.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/dbd $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ad $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/afppasswd $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/afpd $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_dbd $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_metad $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/uams/*.so $(1)/usr/lib/uams/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/afp.conf $(1)/etc/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/extmap.conf $(1)/etc/
+	$(INSTALL_BIN) ./files/afpd.init $(1)/etc/init.d/afpd
+endef
+
+$(eval $(call BuildPackage,netatalk))

--- a/net/netatalk/files/afpd.init
+++ b/net/netatalk/files/afpd.init
@@ -1,0 +1,23 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010-2012 OpenWrt.org
+
+START=80
+STOP=10
+
+USE_PROCD=1
+
+start_service() {
+        mkdir -p /var/netatalk/CNID/
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/afpd -d -F /etc/afp.conf
+	procd_set_param file /etc/afp.conf
+	procd_set_param respawn
+	procd_close_instance
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/cnid_metad -d
+	procd_set_param respawn
+	procd_close_instance
+}
+

--- a/net/netatalk/patches/001-automake-compat.patch
+++ b/net/netatalk/patches/001-automake-compat.patch
@@ -1,0 +1,9 @@
+--- a/macros/iconv.m4
++++ b/macros/iconv.m4
+@@ -115,6 +115,5 @@ int main() {
+ 
+         CFLAGS="$savedcflags"
+         LDFLAGS="$savedldflags"
+-	CPPFLAGS="$saved_CPPFLAGS"
+ 	
+ ])

--- a/net/netatalk/patches/002-ld_library_path.patch
+++ b/net/netatalk/patches/002-ld_library_path.patch
@@ -1,0 +1,26 @@
+--- a/macros/db3-check.m4
++++ b/macros/db3-check.m4
+@@ -148,9 +148,9 @@ if test "x$bdb_required" = "xyes"; then
+                         dnl -- LD_LIBRARY_PATH on many platforms. This will be fairly
+                         dnl -- portable hopefully. Reference:
+                         dnl -- http://lists.gnu.org/archive/html/autoconf/2009-03/msg00040.html
+-                        eval export $shlibpath_var=$bdblibdir
++#                        eval export $shlibpath_var=$bdblibdir
+                         NETATALK_BDB_TRY_LINK
+-                        eval export $shlibpath_var=$saved_shlibpath_var
++#                        eval export $shlibpath_var=$saved_shlibpath_var
+ 
+                         if test x"${atalk_cv_bdb_version}" = x"yes"; then
+                             BDB_CFLAGS="-I${bdbdir}/include${subdir}"
+@@ -177,9 +177,9 @@ if test "x$bdb_required" = "xyes"; then
+                            CPPFLAGS="-I${bdbdir}/include${subdir} $CPPFLAGS"
+                            LDFLAGS="-L$bdblibdir $LDFLAGS"
+ 
+-                           eval export $shlibpath_var=$bdblibdir
++#                           eval export $shlibpath_var=$bdblibdir
+                            NETATALK_BDB_TRY_LINK
+-                           eval export $shlibpath_var=$saved_shlibpath_var
++#                           eval export $shlibpath_var=$saved_shlibpath_var
+ 
+                            if test x"${atalk_cv_bdb_version}" = x"yes"; then
+                               BDB_CFLAGS="-I${bdbdir}/include${subdir}"

--- a/net/netatalk/patches/010-gcc10.patch
+++ b/net/netatalk/patches/010-gcc10.patch
@@ -1,0 +1,20 @@
+From 32df6e155ccfc83216321925273c3e75e631ebe6 Mon Sep 17 00:00:00 2001
+From: Andrew Bauer <zonexpertconsulting@outlook.com>
+Date: Wed, 22 Jan 2020 09:59:47 -0600
+Subject: [PATCH] fix ftbs multiple def of invalid_dircache_entries
+
+---
+ etc/afpd/directory.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/etc/afpd/directory.h
++++ b/etc/afpd/directory.h
+@@ -91,7 +91,7 @@ struct maccess {
+ #define	AR_UWRITE	(1<<2)
+ #define	AR_UOWN		(1<<7)
+ 
+-q_t *invalid_dircache_entries;
++extern q_t *invalid_dircache_entries;
+ 
+ typedef int (*dir_loop)(struct dirent *, char *, void *);
+ 


### PR DESCRIPTION
It's time to park this package.

AppleShare products have been unused for a while now (since Mac OS 9.2.2)
around 2002.
So, there should be fewer users requiring this package.

Last update of netatalk was in December 2018. Not sure if newer updates
will be created.

It's time to cut the cord on our end and move it to the abandoned packages.

Info: https://en.wikipedia.org/wiki/AppleShar

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>