### PR TITLE
python-packages: Import from packages feed

### DIFF
--- a/lang/python/django-appconf/Makefile
+++ b/lang/python/django-appconf/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2007-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-appconf
+PKG_VERSION:=1.0.4
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=be58deb54a43d77d2e1621fe59f787681376d3cd0b8bd8e4758ef6c3a6453380
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-appconf
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Helper class for handling config defaults
+  URL:=https://django-appconf.readthedocs.io
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1 \
+	+python3-six
+endef
+
+define Package/python3-django-appconf/description
+  A helper class for handling configuration defaults of packaged apps gracefully
+endef
+
+$(eval $(call Py3Package,python3-django-appconf))
+$(eval $(call BuildPackage,python3-django-appconf))
+$(eval $(call BuildPackage,python3-django-appconf-src))

--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2007-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-compressor
+PKG_VERSION:=2.4
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PYPI_SOURCE_NAME:=django_compressor
+PKG_HASH:=d2ed1c6137ddaac5536233ec0a819e14009553fee0a869bea65d03e5285ba74f
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-compressor
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Compress CSS/JS into single cached files
+  URL:=https://django-compressor.readthedocs.io
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1 \
+	+python3-django-appconf \
+	+python3-rcssmin
+endef
+
+define Package/python3-django-compressor/description
+  Compresses linked and inline JavaScript or CSS into single cached files.
+  Note that the JavaScript filter is not being installed as a dependency.
+  You'll need to build the rjsmin module (it is not par of the openwrt standard
+  feeds) to use JavaScript functionality.
+endef
+
+$(eval $(call Py3Package,python3-django-compressor))
+$(eval $(call BuildPackage,python3-django-compressor))
+$(eval $(call BuildPackage,python3-django-compressor-src))

--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -1,0 +1,42 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-formtools
+PKG_VERSION:=2.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=c5272c03c1cd51b2375abf7397a199a3148a9fbbf2f100e186467a84025d13b2
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-formtools
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=High-level abstractions for Django forms
+  URL:=https://django-formtools.readthedocs.io
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1
+endef
+
+define Package/python3-django-formtools/description
+  Django "formtools" is a set of high-level abstractions for Django forms.
+  Currently for form previews and multi-step forms.
+endef
+
+$(eval $(call Py3Package,python3-django-formtools))
+$(eval $(call BuildPackage,python3-django-formtools))
+$(eval $(call BuildPackage,python3-django-formtools-src))

--- a/lang/python/django-jsonfield/Makefile
+++ b/lang/python/django-jsonfield/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2007-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-jsonfield
+PKG_VERSION:=2.1.1
+PKG_RELEASE:=2
+
+PYPI_NAME:=jsonfield
+PKG_HASH:=ed7c5e1829e9453e24a8bebef1e702ffe402e6def6b326f0e0b88764c59a6dc7
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-jsonfield
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=A reusable Django field to store validated JSON in models
+  URL:=https://github.com/rpkilby/jsonfield
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1 \
+	+python3-six
+endef
+
+define Package/python3-django-jsonfield/description
+  jsonfield is a reusable model field that allows you to store validated
+  JSON, automatically handling serialization to and from the database.
+endef
+
+$(eval $(call Py3Package,python3-django-jsonfield))
+$(eval $(call BuildPackage,python3-django-jsonfield))
+$(eval $(call BuildPackage,python3-django-jsonfield-src))

--- a/lang/python/django-jsonfield2/Makefile
+++ b/lang/python/django-jsonfield2/Makefile
@@ -1,0 +1,49 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+# Please do not update: 3.0.3 is the last version compatible with Django 1.11
+PKG_NAME:=django-jsonfield2
+PKG_VERSION:=3.0.3
+PKG_RELEASE:=1
+
+# Source for 3.0.3 is not available from PyPI
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/rpkilby/jsonfield2/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=4b79ac28738671fe27cadbd537d50130c35a286207d31d8320c7b48b6cda36ca
+
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/jsonfield2-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-jsonfield2
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=A reusable Django field to store validated JSON in models
+  URL:=https://github.com/rpkilby/jsonfield2
+  DEPENDS:=+python3-light +python3-decimal +django
+  CONFLICTS:=python3-django-jsonfield
+endef
+
+define Package/python3-django-jsonfield2/description
+  A modern fork of django-jsonfield, compatible with the latest versions
+  of Django.
+
+  jsonfield2 is a reusable model field that allows you to store
+  validated JSON, automatically handling serialization to and from the
+  database.
+endef
+
+$(eval $(call Py3Package,python3-django-jsonfield2))
+$(eval $(call BuildPackage,python3-django-jsonfield2))
+$(eval $(call BuildPackage,python3-django-jsonfield2-src))

--- a/lang/python/django-picklefield/Makefile
+++ b/lang/python/django-picklefield/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2007-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-picklefield
+PKG_VERSION:=2.1.1
+PKG_RELEASE:=2
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=67a5e156343e3b032cac2f65565f0faa81635a99c7da74b0f07a0f5db467b646
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+PYTHON3_PKG_SETUP_VARS:= \
+  PKG_VERSION="$(PKG_VERSION)"
+
+define Package/python3-django-picklefield
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Pickled object field for Django
+  URL:=https://github.com/gintas/django-picklefield/
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1
+endef
+
+define Package/python3-django-picklefield/description
+  Pickled object field for Django
+endef
+
+$(eval $(call Py3Package,python3-django-picklefield))
+$(eval $(call BuildPackage,python3-django-picklefield))
+$(eval $(call BuildPackage,python3-django-picklefield-src))

--- a/lang/python/django-picklefield/patches/001-no-import-self-during-setup.patch
+++ b/lang/python/django-picklefield/patches/001-no-import-self-during-setup.patch
@@ -1,0 +1,19 @@
+--- a/setup.py
++++ b/setup.py
+@@ -2,14 +2,14 @@ from __future__ import unicode_literals
+ 
+ from setuptools import find_packages, setup
+ 
+-import picklefield
++import os
+ 
+ with open('README.rst') as file_:
+     long_description = file_.read()
+ 
+ setup(
+     name='django-picklefield',
+-    version=picklefield.__version__,
++    version=os.getenv('PKG_VERSION'),
+     description='Pickled object field for Django',
+     long_description=long_description,
+     author='Simon Charette',

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2007-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+# Please do not update: 3.3.0 is the last version compatible with Django 1.11
+PKG_NAME:=django-postoffice
+PKG_VERSION:=3.3.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=django-post-office
+PYPI_SOURCE_NAME:=django-post_office
+PKG_HASH:=b06514da601c22e955bd93a4ac6dd6b2218c571ca67c193e62bd1f22cec7536f
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-postoffice
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=A Django app to monitor and send mail asynchronously
+  URL:=https://github.com/ui/django-post_office
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1 \
+	+python3-django-jsonfield2
+endef
+
+define Package/python3-django-postoffice/description
+  A Django app to monitor and send mail asynchronously, complete with template
+  support
+endef
+
+$(eval $(call Py3Package,python3-django-postoffice))
+$(eval $(call BuildPackage,python3-django-postoffice))
+$(eval $(call BuildPackage,python3-django-postoffice-src))

--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -1,0 +1,41 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-ranged-response
+PKG_VERSION:=0.2.0
+PKG_RELEASE:=8
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=f71fff352a37316b9bead717fc76e4ddd6c9b99c4680cdf4783b9755af1cf985
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-ranged-response
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Add Content-Range: to FileResponse
+  URL:=https://github.com/i3thuan5/django-ranged-response
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1
+endef
+
+define Package/python3-django-ranged-response/description
+  Modified Django FileResponse that adds Content-Range headers.
+endef
+
+$(eval $(call Py3Package,python3-django-ranged-response))
+$(eval $(call BuildPackage,python3-django-ranged-response))
+$(eval $(call BuildPackage,python3-django-ranged-response-src))

--- a/lang/python/django-restframework39/Makefile
+++ b/lang/python/django-restframework39/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2007-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-restframework39
+PKG_VERSION:=3.9.4
+PKG_RELEASE:=2
+
+PYPI_NAME:=djangorestframework
+PKG_HASH:=c12869cfd83c33d579b17b3cb28a2ae7322a53c3ce85580c2a2ebe4e3f56c4fb
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.md
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-restframework39
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Web APIs for Django, made easy.
+  URL:=https://www.django-rest-framework.org
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1
+  CONFLICTS:=python3-django-restframework
+endef
+
+define Package/python3-django-restframework39/description
+  Web APIs for Django, made easy. (3.9 series)
+endef
+
+$(eval $(call Py3Package,python3-django-restframework39))
+$(eval $(call BuildPackage,python3-django-restframework39))
+$(eval $(call BuildPackage,python3-django-restframework39-src))

--- a/lang/python/django-simple-captcha/Makefile
+++ b/lang/python/django-simple-captcha/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2007-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-simple-captcha
+PKG_VERSION:=0.5.12
+PKG_RELEASE:=4
+
+PYPI_NAME:=$(PKG_NAME)
+PYPI_SOURCE_EXT:=zip
+PKG_HASH:=fc25f0425e282aa82d2a65013049a8dc7c0682f8e05d32681c39a0c55ed322bd
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-simple-captcha
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Simple Django captcha application
+  URL:=https://github.com/mbi/django-simple-captcha
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-six \
+	+python3-django1 \
+	+python3-pillow \
+	+python3-django-ranged-response
+endef
+
+define Package/python3-django-simple-captcha/description
+  Django Simple Captcha is an extremely simple, yet highly customizable Django
+  application to add captcha images to any Django form.
+endef
+
+$(eval $(call Py3Package,python3-django-simple-captcha))
+$(eval $(call BuildPackage,python3-django-simple-captcha))
+$(eval $(call BuildPackage,python3-django-simple-captcha-src))

--- a/lang/python/django-statici18n/Makefile
+++ b/lang/python/django-statici18n/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2007-2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-statici18n
+PKG_VERSION:=1.9.0
+PKG_RELEASE:=2
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=913dd056c1abcbe129b1db806cb4cfb821c4077d7e857d6eb29043ea64f4d1d0
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-statici18n
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Helper for generating JavaScript catalog to static files
+  URL:=https://django-statici18n.readthedocs.io
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1 \
+	+python3-django-appconf \
+	+python3-six
+endef
+
+define Package/python3-django-statici18n/description
+  A Django app that provides helper for generating JavaScript catalog to static files.
+endef
+
+$(eval $(call Py3Package,python3-django-statici18n))
+$(eval $(call BuildPackage,python3-django-statici18n))
+$(eval $(call BuildPackage,python3-django-statici18n-src))

--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -1,0 +1,41 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-webpack-loader
+PKG_VERSION:=0.7.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=7a3c88201aa54481f9399465615cbe7b9aece8081496a6d0287b7cb8e232f447
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-webpack-loader
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Transparently use webpack in django
+  URL:=https://github.com/owais/django-webpack-loader
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-django1
+endef
+
+define Package/python3-django-webpack-loader/description
+  Use webpack to generate your static bundles without django’s staticfiles or opaque wrappers.
+endef
+
+$(eval $(call Py3Package,python3-django-webpack-loader))
+$(eval $(call BuildPackage,python3-django-webpack-loader))
+$(eval $(call BuildPackage,python3-django-webpack-loader-src))

--- a/lang/python/django1/Makefile
+++ b/lang/python/django1/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) Alexandru Ardelean <ardeleanalex@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django1
+PKG_VERSION:=1.11.29
+PKG_RELEASE:=4
+
+PYPI_NAME:=Django
+PKG_HASH:=4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE LICENSE.python
+PKG_CPE_ID:=cpe:/a:djangoproject:django
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django1
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=The web framework for perfectionists with deadlines.
+  URL:=https://www.djangoproject.com/
+  DEPENDS:= \
+	@BROKEN \
+	+python3 \
+	+python3-pytz
+  PROVIDES:=django
+endef
+
+define Package/python3-django1/description
+  The web framework for perfectionists with deadlines (LTS 1.11 series).
+endef
+
+define Py3Package/python3-django1/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/django-admin.py \
+		$(1)/usr/bin/django-admin
+endef
+
+$(eval $(call Py3Package,python3-django1))
+$(eval $(call BuildPackage,python3-django1))
+$(eval $(call BuildPackage,python3-django1-src))

--- a/lang/python/django1/patches/001-load-byte-compiled-db-migrations.patch
+++ b/lang/python/django1/patches/001-load-byte-compiled-db-migrations.patch
@@ -1,0 +1,11 @@
+--- a/django/db/migrations/loader.py
++++ b/django/db/migrations/loader.py
+@@ -106,7 +106,7 @@ class MigrationLoader(object):
+             # Scan for .py files
+             migration_names = set()
+             for name in os.listdir(directory):
+-                if name.endswith(".py"):
++                if name.endswith(".py") or name.endswith(".pyc"):
+                     import_name = name.rsplit(".", 1)[0]
+                     if import_name[0] not in "_.~":
+                         migration_names.add(import_name)

--- a/lang/python/gunicorn/Makefile
+++ b/lang/python/gunicorn/Makefile
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2007-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gunicorn
+PKG_VERSION:=20.1.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/gunicorn/Default
+  SUBMENU:=Web Servers/Proxies
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=WSGI HTTP Server for UNIX
+  URL:=https://gunicorn.org
+endef
+
+define Package/python3-gunicorn
+$(call Package/gunicorn/Default)
+  TITLE:=WSGI HTTP Server for UNIX (library)
+  DEPENDS:=+python3
+endef
+
+define Package/python3-gunicorn/description
+    WSGI HTTP Server for UNIX (libraries)
+endef
+
+# Make sure that the binaries are not installed with the libraries
+# That means adding some empty Py3Package/gunicorn3/install rules
+define Py3Package/python3-gunicorn/install
+	:
+endef
+
+define Package/gunicorn3
+$(call Package/gunicorn/Default)
+  DEPENDS:=+python3 +python3-setuptools +python3-gunicorn
+endef
+
+define Package/gunicorn3/description
+    WSGI HTTP Server for UNIX (daemon)
+endef
+
+define Package/gunicorn3/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/gunicorn \
+		$(1)/usr/bin/gunicorn3
+	$(LN) gunicorn3 $(1)/usr/bin/gunicorn
+	$(call Python3/FixShebang,$(1)/usr/bin/*)
+endef
+
+$(eval $(call Py3Package,python3-gunicorn))
+$(eval $(call BuildPackage,python3-gunicorn))
+$(eval $(call BuildPackage,python3-gunicorn-src))
+$(eval $(call BuildPackage,gunicorn3))

--- a/lang/python/pyjwt/Makefile
+++ b/lang/python/pyjwt/Makefile
@@ -1,0 +1,38 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pyjwt
+PKG_VERSION:=2.2.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PYPI_NAME:=PyJWT
+PKG_HASH:=a0b9a3b4e5ca5517cac9f1a6e9cd30bf1aa80be74fcdf4e28eded582ecfcfbae
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pyjwt
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=JSON Web Token implementation in Python
+  URL:=http://github.com/jpadilla/pyjwt
+  DEPENDS:=+python3
+endef
+
+define Package/python3-pyjwt/description
+  A Python implementation of RFC 7519.
+endef
+
+$(eval $(call Py3Package,python3-pyjwt))
+$(eval $(call BuildPackage,python3-pyjwt))
+$(eval $(call BuildPackage,python3-pyjwt-src))

--- a/lang/python/python-oauthlib/Makefile
+++ b/lang/python/python-oauthlib/Makefile
@@ -1,0 +1,39 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-oauthlib
+PKG_VERSION:=3.1.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PYPI_NAME:=oauthlib
+PKG_HASH:=8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-oauthlib
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=OAuth request-signing logic for Python
+  URL:=https://github.com/oauthlib/oauthlib
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-oauthlib/description
+  A generic, spec-compliant, thorough implementation of the OAuth request-signing
+  logic for Python
+endef
+
+$(eval $(call Py3Package,python3-oauthlib))
+$(eval $(call BuildPackage,python3-oauthlib))
+$(eval $(call BuildPackage,python3-oauthlib-src))

--- a/lang/python/python-qrcode/Makefile
+++ b/lang/python/python-qrcode/Makefile
@@ -1,0 +1,41 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-qrcode
+PKG_VERSION:=7.3.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=qrcode
+PKG_HASH:=375a6ff240ca9bd41adc070428b5dfc1dcfbb0f2507f1ac848f6cded38956578
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-qrcode
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=QR Code image generator
+  URL:=https://github.com/lincolnloop/python-qrcode
+  DEPENDS:= \
+	+python3 \
+	+python3-setuptools \
+	+python3-pillow
+endef
+
+define Package/python3-qrcode/description
+  Pure python QR Code generator
+endef
+
+$(eval $(call Py3Package,python3-qrcode))
+$(eval $(call BuildPackage,python3-qrcode))
+$(eval $(call BuildPackage,python3-qrcode-src))

--- a/lang/python/python-rcssmin/Makefile
+++ b/lang/python/python-rcssmin/Makefile
@@ -1,0 +1,43 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-rcssmin
+PKG_VERSION:=1.1.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PYPI_NAME:=rcssmin
+PKG_HASH:=27fc400627fd3d328b7fe95af2a01f5d0af6b5af39731af5d071826a1f08e362
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-rcssmin
+    SUBMENU:=Python
+    SECTION:=lang
+    CATEGORY:=Languages
+    TITLE:=Fast CSS minifier for Python
+    URL:=http://opensource.perlig.de/rcssmin/
+    DEPENDS:= \
+	+python3-light
+endef
+
+define Package/python3-rcssmin/description
+    This module is a re-implementation aiming for speed instead of maximum compression,
+    so it can be used at runtime (rather than during a preprocessing step).
+    RCSSmin does syntactical compression only (removing spaces, comments and possibly
+    semicolons). It does not provide semantic compression (like removing empty blocks,
+    collapsing redundant properties etc).
+endef
+
+$(eval $(call Py3Package,python3-rcssmin))
+$(eval $(call BuildPackage,python3-rcssmin))
+$(eval $(call BuildPackage,python3-rcssmin-src))

--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -1,0 +1,42 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-requests-oauthlib
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=2
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=LICENSE
+
+PYPI_NAME:=requests-oauthlib
+PKG_HASH:=b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-requests-oauthlib
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=OAuthlib auth for Requests
+  URL:=https://github.com/requests/requests-oauthlib
+  DEPENDS:= \
+	+python3 \
+	+python3-oauthlib \
+	+python3-requests
+endef
+
+define Package/python3-requests-oauthlib/description
+  This python package provides first-class OAuth library support
+  for Requests.
+endef
+
+$(eval $(call Py3Package,python3-requests-oauthlib))
+$(eval $(call BuildPackage,python3-requests-oauthlib))
+$(eval $(call BuildPackage,python3-requests-oauthlib-src))


### PR DESCRIPTION
These are library packages that have no use after the removal of Seafile.

Removed from the packages feed in https://github.com/openwrt/packages/pull/18016.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>