### PR TITLE
Mako: Import from packages feed

### DIFF
--- a/lang/python/Mako/Makefile
+++ b/lang/python/Mako/Makefile
@@ -1,0 +1,48 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=Mako
+PKG_VERSION:=1.1.5
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=169fa52af22a91900d852e937400e79f535496191c63712e3b9fda5a9bed6fc3
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.rst
+PKG_CPE_ID:=cpe:/a:palletsprojects:flask
+
+HOST_BUILD_DEPENDS:=python3/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-mako
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Mako
+  URL:=https://www.makotemplates.org/
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-mako/description
+ Mako is a template library written in Python.
+endef
+
+define Host/Compile
+	$(call HostPython3/ModSetup,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+endef
+
+Host/Install:=
+
+$(eval $(call Py3Package,python3-mako))
+$(eval $(call BuildPackage,python3-mako))
+$(eval $(call BuildPackage,python3-mako-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Removed from the packages feed in https://github.com/openwrt/packages/pull/18094.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>