### PR TITLE
ooniprobe: Import from packages feed

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2020-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ooniprobe
+PKG_VERSION:=3.18.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=d28c050226c9282d7155da6cabf5547ddd43dc11eecacc485b6c05161c2d1d88
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/probe-cli-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/ooni/probe-cli
+GO_PKG_BUILD_PKG:=github.com/ooni/probe-cli/v3/cmd/ooniprobe
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/ooniprobe
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=OONI probe-cli
+  URL:=https://ooni.org
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/ooniprobe/description
+  The next generation of Open Observatory of Network Interference (OONI)
+  Probe Command Line Interface.
+endef
+
+# Workaround for musl 1.2.4 compability in mattn/go-sqlite3
+# https://github.com/mattn/go-sqlite3/issues/1164
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
+
+$(eval $(call GoBinPackage,ooniprobe))
+$(eval $(call BuildPackage,ooniprobe))

--- a/net/ooniprobe/test.sh
+++ b/net/ooniprobe/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ooniprobe version | grep "$2"


### PR DESCRIPTION
The package was removed in https://github.com/openwrt/packages/pull/22382.